### PR TITLE
Phase 1: make CI green without touching logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,20 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        # Pinned, not '3.x'. A floating version silently drifts onto a new
+        # release and turns a passing build red months after the last commit.
+        python-version: '3.13'
 
     - name: Cache Python dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
@@ -27,7 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 black
+        pip install -r requirements-dev.txt
 
     - name: Lint with flake8
       run: |
@@ -37,6 +39,9 @@ jobs:
       run: |
         black --check ee_lst/ tests/ examples/ validation/
 
+    # Stays commented until phase 3 replaces the placeholder tests.
+    # All 10 test functions currently fail: 8 call functions that do not
+    # exist, 2 call live Earth Engine. See .refresh/baseline.md.
     # - name: Run tests
     #   run: |
     #     python -m pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,17 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         # Pinned, not '3.x'. A floating version silently drifts onto a new
         # release and turns a passing build red months after the last commit.
         python-version: '3.13'
 
     - name: Cache Python dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}

--- a/.github/workflows/refactoring_validation.yml
+++ b/.github/workflows/refactoring_validation.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up credentials
         run: |

--- a/.github/workflows/refactoring_validation.yml
+++ b/.github/workflows/refactoring_validation.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up credentials
         run: |

--- a/ee_lst/landsat_lst.py
+++ b/ee_lst/landsat_lst.py
@@ -92,6 +92,6 @@ def fetch_landsat_collection(landsat, date_start, date_end, geometry, use_ndvi):
     landsat_lst = landsat_all.map(lambda image: add_lst_band(landsat, image))
 
     # Add timestamp to each image in the collection
-    landsat_lst = landsat_lst.map(add_timestamp) #.map(add_raw_timestamp)
+    landsat_lst = landsat_lst.map(add_timestamp)  # .map(add_raw_timestamp)
 
     return landsat_lst

--- a/ee_lst/landsat_lst.py
+++ b/ee_lst/landsat_lst.py
@@ -23,8 +23,8 @@ def initialize_ee():
 
 
 def add_timestamp(image):
-    timestamp = image.getNumber('system:time_start')
-    return image.addBands(ee.Image.constant(timestamp).rename('TIMESTAMP'))
+    timestamp = image.getNumber("system:time_start")
+    return image.addBands(ee.Image.constant(timestamp).rename("TIMESTAMP"))
     # # Convert the system:time_start property to a human-readable string
     # timestamp_string = ee.Date(image.get("system:time_start")).format(
     #     "YYYY-MM-DD HH:mm:ss"
@@ -57,10 +57,8 @@ def fetch_landsat_collection(landsat, date_start, date_end, geometry, use_ndvi):
 
     # Check if the provided Landsat collection is valid
     if landsat not in LANDSAT_BANDS.keys():
-        raise ValueError(
-            f"Invalid Landsat constellation: {landsat}. \
-            Valid options are: {list(LANDSAT_BANDS.keys())}"
-        )
+        raise ValueError(f"Invalid Landsat constellation: {landsat}. \
+            Valid options are: {list(LANDSAT_BANDS.keys())}")
 
     collection_dict = LANDSAT_BANDS[landsat]
 

--- a/examples/example_1.ipynb
+++ b/examples/example_1.ipynb
@@ -1,807 +1,834 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a6186a3b-537b-4678-8199-021a0a3e957a",
-      "metadata": {
-        "jupyter": {
-          "outputs_hidden": false,
-          "source_hidden": false
-        },
-        "noteable": {
-          "cell_type": "code"
-        }
-      },
-      "outputs": [],
-      "source": []
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6186a3b-537b-4678-8199-021a0a3e957a",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false,
+     "source_hidden": false
     },
-    {
-      "cell_type": "markdown",
-      "id": "27c7ba38-7588-4597-966a-938df4f3c29d",
-      "metadata": {
-        "noteable": {
-          "cell_type": "markdown"
-        }
-      },
-      "source": [
-        "# Landsat LST Example\n",
-        "\n",
-        "In this notebook, we will demonstrate how to fetch and visualize Landsat Land Surface Temperature (LST) data using the `ee_lst` library and Google Earth Engine API. We'll use `geemap` for interactive map visualizations with layer controls.\n",
-        "The layers are derived from the `example_1.py` script, and the explanations are based on the paper titled [\"A Google Earth Engine Free App for Estimating Near-Real Time Daily Surface Temperature from Landsat Data\"](https://www.mdpi.com/2072-4292/12/9/1471/pdf?version=1589365556)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "6b7cfad2-ba2d-4143-bf4d-c006d36aeb2c",
-      "metadata": {
-        "noteable": {
-          "cell_type": "code"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "import ee"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "eb1ca586",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Initialize the Earth Engine API\n",
-        "if not ee.data._initialized:\n",
-        "    try:\n",
-        "        ee.Initialize()\n",
-        "    except Exception as e:\n",
-        "        print(\"Please authenticate Google Earth Engine first.\")\n",
-        "        ee.Authenticate()\n",
-        "        ee.Initialize()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2319a9ab-d975-433b-8b67-95c6ca410d9a",
-      "metadata": {
-        "noteable": {
-          "cell_type": "markdown"
-        }
-      },
-      "source": [
-        "## Fetching Landsat Data\n",
-        "\n",
-        "We will fetch Landsat data for a specific region and time range. The data will include added variables such as NDVI, FVC, TPW, EM, and LST."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a6550263",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -q git+https://github.com/lunasilvestre/ee_lst.git"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "e3805c69",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from modules.landsat_lst import fetch_landsat_collection"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "5baeff27-ddfd-41d3-8b12-68c4d78ad4f6",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2023-09-10T10:43:49.758197+00:00",
-          "start_time": "2023-09-10T10:43:49.407534+00:00"
-        },
-        "noteable": {
-          "cell_type": "code",
-          "output_collection_id": "b27c00f7-8e69-4953-bc49-87e1b6f73e2a"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# Define parameters\n",
-        "geometry = ee.Geometry.Rectangle([-8.91, 40.0, -8.3, 40.4])\n",
-        "satellite = 'L8'\n",
-        "date_start = '2023-05-15'\n",
-        "date_end = '2023-10-15'\n",
-        "use_ndvi = True\n",
-        "\n",
-        "# Get Landsat collection with added variables: NDVI, FVC, TPW, EM, LST\n",
-        "landsat_coll = fetch_landsat_collection(satellite, date_start, date_end, geometry, use_ndvi)\n",
-        "landsat_coll = landsat_coll.sort('TIMESTAMP')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0bc0c3e9-0e73-452a-9145-7ef8c6245c4e",
-      "metadata": {
-        "noteable": {
-          "cell_type": "markdown"
-        }
-      },
-      "source": [
-        "## Visualizing Landsat Data with geemap\n",
-        "\n",
-        "Now that we have fetched the Landsat data, let's visualize it on an interactive map using `geemap`. We will display the Land Surface Temperature (LST) layer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "b0cf9092",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "/bin/bash: line 1: jupyter-nbextension: command not found\n"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install ipyleaflet\n",
-        "# !jupyter-nbextension enable --py --sys-prefix ipyleaflet"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "a8f9897d",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]\n",
-            "               [--paths] [--json] [--debug]\n",
-            "               [subcommand]\n",
-            "\n",
-            "Jupyter: Interactive Computing\n",
-            "\n",
-            "positional arguments:\n",
-            "  subcommand     the subcommand to launch\n",
-            "\n",
-            "optional arguments:\n",
-            "  -h, --help     show this help message and exit\n",
-            "  --version      show the versions of core jupyter packages and exit\n",
-            "  --config-dir   show Jupyter config dir\n",
-            "  --data-dir     show Jupyter data dir\n",
-            "  --runtime-dir  show Jupyter runtime dir\n",
-            "  --paths        show all Jupyter paths. Add --json for machine-readable\n",
-            "                 format.\n",
-            "  --json         output paths as machine-readable json\n",
-            "  --debug        output debug information about paths\n",
-            "\n",
-            "Available subcommands: kernel kernelspec migrate run troubleshoot\n",
-            "\n",
-            "Jupyter command `jupyter-labextension` not found.\n"
-          ]
-        }
-      ],
-      "source": [
-        "!jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "id": "0ea7357f",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "b3492465a07d462997e977534e628ff7",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "IntSlider(value=0)"
-            ]
-          },
-          "execution_count": 19,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "from ipywidgets import IntSlider\n",
-        "slider = IntSlider()\n",
-        "slider"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "cd086de6",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "058f9fe92a914f6dbe179545ae4ee56f",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Map(center=[0.0, 0.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out_t…"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import ipyleaflet\n",
-        "m = ipyleaflet.Map()\n",
-        "m"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "85f4f957",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Installs geemap package\n",
-        "import subprocess\n",
-        "\n",
-        "try:\n",
-        "    import geemap\n",
-        "except ImportError:\n",
-        "    print('Installing geemap ...')\n",
-        "    subprocess.check_call([\"python\", '-m', 'pip', 'install', 'geemap'])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "53fec8e7",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# import ee\n",
-        "import geemap"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2c816877",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# geemap.update_package()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d0ef2d11",
-      "metadata": {},
-      "source": [
-        "## Create an interactive map\n",
-        "The default basemap is Google Maps. Additional basemaps can be added using the Map.add_basemap() function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "65a4ecce",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "            <style>\n",
-              "                .geemap-dark {\n",
-              "                    --jp-widgets-color: white;\n",
-              "                    --jp-widgets-label-color: white;\n",
-              "                    --jp-ui-font-color1: white;\n",
-              "                    --jp-layout-color2: #454545;\n",
-              "                    background-color: #383838;\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-dark .jupyter-button {\n",
-              "                    --jp-layout-color3: #383838;\n",
-              "                }\n",
-              "                \n",
-              "                .geemap-colab {\n",
-              "                    background-color: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "                    \n",
-              "                .geemap-colab .jupyter-button {\n",
-              "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
-              "                }\n",
-              "            </style>\n",
-              "            "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "91bbe5fe6e7746cc9559b3fe20a9650f",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Map(center=[0, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=SearchDataGUI(childr…"
-            ]
-          },
-          "execution_count": 16,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "Map = geemap.Map() #center=[40,-100], zoom=4)\n",
-        "Map"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3e2584b2",
-      "metadata": {},
-      "source": [
-        "## Visualizing Landsat Data with folium\n",
-        "\n",
-        "Now that we have fetched the Landsat data, let's visualize it on an interactive map using `folium`. We will display the Land Surface Temperature (LST) layer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f5573252",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import folium\n",
-        "from folium import plugins"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "834eeebe",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Define a method for displaying Earth Engine image tiles on a folium map.\n",
-        "def add_ee_layer(self, ee_object, vis_params, name):\n",
-        "    \n",
-        "    try:    \n",
-        "        tile_layer = None\n",
-        "        # display ee.Image()\n",
-        "        if isinstance(ee_object, ee.image.Image):    \n",
-        "            map_id_dict = ee.Image(ee_object).getMapId(vis_params)\n",
-        "            tile_layer = folium.raster_layers.TileLayer(\n",
-        "            tiles = map_id_dict['tile_fetcher'].url_format,\n",
-        "            attr = 'Google Earth Engine',\n",
-        "            name = name,\n",
-        "            overlay = True,\n",
-        "            control = True\n",
-        "            )\n",
-        "            tile_layer.add_to(self)\n",
-        "\n",
-        "        # display ee.ImageCollection()\n",
-        "        elif isinstance(ee_object, ee.imagecollection.ImageCollection):    \n",
-        "            ee_object_new = ee_object.mosaic()\n",
-        "            map_id_dict = ee.Image(ee_object_new).getMapId(vis_params)\n",
-        "            tile_layer = folium.raster_layers.TileLayer(\n",
-        "            tiles = map_id_dict['tile_fetcher'].url_format,\n",
-        "            attr = 'Google Earth Engine',\n",
-        "            name = name,\n",
-        "            overlay = True,\n",
-        "            control = True\n",
-        "            )\n",
-        "            tile_layer.add_to(self)\n",
-        "\n",
-        "        # display ee.Geometry()\n",
-        "        elif isinstance(ee_object, ee.geometry.Geometry):    \n",
-        "            folium.GeoJson(\n",
-        "            data = ee_object.getInfo(),\n",
-        "            name = name,\n",
-        "            overlay = True,\n",
-        "            control = True\n",
-        "        ).add_to(self)\n",
-        "\n",
-        "        # display ee.FeatureCollection()\n",
-        "        elif isinstance(ee_object, ee.featurecollection.FeatureCollection):  \n",
-        "            ee_object_new = ee.Image().paint(ee_object, 0, 2)\n",
-        "            map_id_dict = ee.Image(ee_object_new).getMapId(vis_params)\n",
-        "            tile_layer = folium.raster_layers.TileLayer(\n",
-        "            tiles = map_id_dict['tile_fetcher'].url_format,\n",
-        "            attr = 'Google Earth Engine',\n",
-        "            name = name,\n",
-        "            overlay = True,\n",
-        "            control = True\n",
-        "        )\n",
-        "        tile_layer.add_to(self)\n",
-        "\n",
-        "        print(tile_layer)\n",
-        "        return tile_layer\n",
-        "    except:\n",
-        "        print(\"Could not display {}\".format(name))\n",
-        "        return None\n",
-        "\n",
-        "\n",
-        "# Add EE drawing method to folium.\n",
-        "folium.Map.add_ee_layer = add_ee_layer"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0c670564-eaa5-47cf-87c6-0453dc64dde6",
-      "metadata": {
-        "noteable": {
-          "cell_type": "code"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "# Get Landsat collection first image\n",
-        "# ex_image = landsat_coll.first()\n",
-        "\n",
-        "# Visualization parameters\n",
-        "cmap1 = ['blue', 'cyan', 'green', 'yellow', 'red']\n",
-        "cmap2 = ['F2F2F2','EFC2B3','ECB176','E9BD3A','E6E600','63C600','00A600']\n",
-        "\n",
-        "\n",
-        "# Add the Earth Engine layers to the folium map\n",
-        "layers = [\n",
-        "    {'band': 'TPW', 'vis_params': {'min': 0, 'max': 60, 'palette': cmap1}, 'name': 'TCWV'},\n",
-        "    {'band': 'TPWpos', 'vis_params': {'min': 0, 'max': 9, 'palette': cmap1}, 'name': 'TCWVpos'},\n",
-        "    {'band': 'FVC', 'vis_params': {'min': 0, 'max': 1, 'palette': cmap2}, 'name': 'FVC'},\n",
-        "    {'band': 'EM', 'vis_params': {'min': 0.9, 'max': 1.0, 'palette': cmap1}, 'name': 'Emissivity'},\n",
-        "    {'band': 'B10', 'vis_params': {'min': 290, 'max': 320, 'palette': cmap1}, 'name': 'TIR BT'},\n",
-        "    {'band': 'LST', 'vis_params': {'min': 290, 'max': 320, 'palette': cmap1}, 'name': 'LST'} #,\n",
-        "    # {'band': 'RGB', 'vis_params': {'bands': ['SR_B4', 'SR_B3', 'SR_B2'], 'min': 0, 'max': 0.3}, 'name': 'RGB'}\n",
-        "]\n",
-        "\n",
-        "# https://stackoverflow.com/questions/64792041/white-gap-between-python-folium-map-and-jupyter-notebook-cell\n",
-        "# Create a folium map object\n",
-        "# from branca.element import Figure\n",
-        "# fig = Figure(height=500) #width=600, \n",
-        "my_map = folium.Map(location=[40.2, -8.6], zoom_start=10, height=500)\n",
-        "# fig.add_child(my_map)\n",
-        "\n",
-        "tile_layers = [] \n",
-        "for layer in layers:\n",
-        "    # tile_layer = my_map.add_ee_layer(ex_image.select(layer['band']), layer['vis_params'], layer['name'])\n",
-        "    tile_layer = my_map.add_ee_layer(landsat_coll.select(layer['band']), layer['vis_params'], layer['name'])\n",
-        "    if tile_layer:\n",
-        "        tile_layers.append(tile_layer)    \n",
-        "\n",
-        "# Add WmsTileLayers to time control.\n",
-        "time = plugins.TimestampedWmsTileLayers(tile_layers)\n",
-        "time.add_to(my_map)\n",
-        "\n",
-        "# Add a layer control panel to the map.\n",
-        "my_map.add_child(folium.LayerControl())\n",
-        "\n",
-        "# Display the map\n",
-        "my_map"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "965f8699",
-      "metadata": {},
-      "source": [
-        "## Explanation of Layers"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "957537ee-6a2a-4103-949a-abcb786fa009",
-      "metadata": {
-        "noteable": {
-          "cell_type": "markdown"
-        }
-      },
-      "source": [
-        "### TCWV (Total Column Water Vapor)\n",
-        "This layer represents the Total Column Water Vapor (TCWV). Water vapor plays a crucial role in the Earth's energy balance, and its distribution is essential for weather forecasting and climate modeling. In the context of urban areas, understanding TCWV can provide insights into urban heat island effects and local climate variations.\n",
-        "\n",
-        "### TCWVpos\n",
-        "This layer is a positive representation of the TCWV. It emphasizes areas with higher water vapor concentrations, which can be particularly relevant in urban climate studies to identify areas of increased humidity or potential heat stress.\n",
-        "\n",
-        "### FVC (Fractional Vegetation Cover)\n",
-        "The Fractional Vegetation Cover (FVC) layer provides a measure of the proportion of ground covered by vegetation. In urban areas, vegetation can play a significant role in mitigating the urban heat island effect, providing shade, and improving air quality. Thus, understanding FVC can help in urban planning and sustainability efforts.\n",
-        "\n",
-        "### Emissivity\n",
-        "Emissivity represents the efficiency of a surface in emitting thermal radiation. Different surfaces, such as buildings, roads, and vegetation, have different emissivity values. In urban areas, understanding surface emissivity can help in assessing the thermal properties of various surfaces and their contribution to local temperature variations.\n",
-        "\n",
-        "### TIR BT (Thermal Infrared Brightness Temperature)\n",
-        "This layer represents the brightness temperature in the thermal infrared spectrum. It provides a direct measure of the surface temperature, which is crucial for understanding urban heat islands and local temperature variations.\n",
-        "\n",
-        "### LST (Land Surface Temperature)\n",
-        "The Land Surface Temperature (LST) layer provides a measure of the temperature of the Earth's surface. In urban areas, LST can vary significantly due to factors like urban heat islands, surface materials, and vegetation cover. Understanding LST is essential for urban climate studies and health assessments.\n",
-        "\n",
-        "### RGB\n",
-        "This layer provides a true-color representation of the area using the Red, Green, and Blue bands. It gives a visual context to the other layers and helps in understanding the spatial distribution of features like vegetation, water bodies, and urban infrastructure.\n",
-        "\n",
-        "The methodologies and significance of these layers are discussed in detail in the paper titled \"[An Open-Source Tool for Automated Quality Assessment of Landsat Surface Temperature over Urban Areas](https://www.mdpi.com/2072-4292/12/9/1471/pdf?version=1589365556)\" by Lorenzo Bigagli, Massimiliano Nole, Simone Mantovani, and Mattia Crespi."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "611d6d90-294a-4936-8f88-5b4c8475439d",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2023-09-10T11:01:24.554244+00:00",
-          "start_time": "2023-09-10T11:01:23.934683+00:00"
-        },
-        "noteable": {
-          "cell_type": "code",
-          "output_collection_id": "2f384f52-38f3-4504-9796-49624dcb58b9"
-        }
-      },
-      "outputs": [],
-      "source": []
+    "noteable": {
+     "cell_type": "code"
     }
-  ],
-  "metadata": {
-    "kernel_info": {
-      "name": "python3"
-    },
-    "kernelspec": {
-      "display_name": "Python 3.9",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.2"
-    },
-    "noteable-chatgpt": {
-      "create_notebook": {
-        "openai_conversation_id": "5b206a8d-1381-5710-8ef9-6ea4c441d9ee",
-        "openai_ephemeral_user_id": "6d6b62e2-4293-50fb-bd1f-908ad0cb15a1",
-        "openai_subdivision1_iso_code": "PT-14"
-      }
-    },
-    "selected_hardware_size": "small"
+   },
+   "outputs": [],
+   "source": []
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "27c7ba38-7588-4597-966a-938df4f3c29d",
+   "metadata": {
+    "noteable": {
+     "cell_type": "markdown"
+    }
+   },
+   "source": [
+    "# Landsat LST Example\n",
+    "\n",
+    "In this notebook, we will demonstrate how to fetch and visualize Landsat Land Surface Temperature (LST) data using the `ee_lst` library and Google Earth Engine API. We'll use `geemap` for interactive map visualizations with layer controls.\n",
+    "The layers are derived from the `example_1.py` script, and the explanations are based on the paper titled [\"A Google Earth Engine Free App for Estimating Near-Real Time Daily Surface Temperature from Landsat Data\"](https://www.mdpi.com/2072-4292/12/9/1471/pdf?version=1589365556)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6b7cfad2-ba2d-4143-bf4d-c006d36aeb2c",
+   "metadata": {
+    "noteable": {
+     "cell_type": "code"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import ee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eb1ca586",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the Earth Engine API\n",
+    "if not ee.data._initialized:\n",
+    "    try:\n",
+    "        ee.Initialize()\n",
+    "    except Exception as e:\n",
+    "        print(\"Please authenticate Google Earth Engine first.\")\n",
+    "        ee.Authenticate()\n",
+    "        ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2319a9ab-d975-433b-8b67-95c6ca410d9a",
+   "metadata": {
+    "noteable": {
+     "cell_type": "markdown"
+    }
+   },
+   "source": [
+    "## Fetching Landsat Data\n",
+    "\n",
+    "We will fetch Landsat data for a specific region and time range. The data will include added variables such as NDVI, FVC, TPW, EM, and LST."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6550263",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q git+https://github.com/lunasilvestre/ee_lst.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3805c69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modules.landsat_lst import fetch_landsat_collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5baeff27-ddfd-41d3-8b12-68c4d78ad4f6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-10T10:43:49.758197+00:00",
+     "start_time": "2023-09-10T10:43:49.407534+00:00"
+    },
+    "noteable": {
+     "cell_type": "code",
+     "output_collection_id": "b27c00f7-8e69-4953-bc49-87e1b6f73e2a"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Define parameters\n",
+    "geometry = ee.Geometry.Rectangle([-8.91, 40.0, -8.3, 40.4])\n",
+    "satellite = \"L8\"\n",
+    "date_start = \"2023-05-15\"\n",
+    "date_end = \"2023-10-15\"\n",
+    "use_ndvi = True\n",
+    "\n",
+    "# Get Landsat collection with added variables: NDVI, FVC, TPW, EM, LST\n",
+    "landsat_coll = fetch_landsat_collection(\n",
+    "    satellite, date_start, date_end, geometry, use_ndvi\n",
+    ")\n",
+    "landsat_coll = landsat_coll.sort(\"TIMESTAMP\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc0c3e9-0e73-452a-9145-7ef8c6245c4e",
+   "metadata": {
+    "noteable": {
+     "cell_type": "markdown"
+    }
+   },
+   "source": [
+    "## Visualizing Landsat Data with geemap\n",
+    "\n",
+    "Now that we have fetched the Landsat data, let's visualize it on an interactive map using `geemap`. We will display the Land Surface Temperature (LST) layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b0cf9092",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/bin/bash: line 1: jupyter-nbextension: command not found\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install ipyleaflet\n",
+    "# !jupyter-nbextension enable --py --sys-prefix ipyleaflet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a8f9897d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]\n",
+      "               [--paths] [--json] [--debug]\n",
+      "               [subcommand]\n",
+      "\n",
+      "Jupyter: Interactive Computing\n",
+      "\n",
+      "positional arguments:\n",
+      "  subcommand     the subcommand to launch\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help     show this help message and exit\n",
+      "  --version      show the versions of core jupyter packages and exit\n",
+      "  --config-dir   show Jupyter config dir\n",
+      "  --data-dir     show Jupyter data dir\n",
+      "  --runtime-dir  show Jupyter runtime dir\n",
+      "  --paths        show all Jupyter paths. Add --json for machine-readable\n",
+      "                 format.\n",
+      "  --json         output paths as machine-readable json\n",
+      "  --debug        output debug information about paths\n",
+      "\n",
+      "Available subcommands: kernel kernelspec migrate run troubleshoot\n",
+      "\n",
+      "Jupyter command `jupyter-labextension` not found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "!jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "0ea7357f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b3492465a07d462997e977534e628ff7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=0)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from ipywidgets import IntSlider\n",
+    "\n",
+    "slider = IntSlider()\n",
+    "slider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "cd086de6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "058f9fe92a914f6dbe179545ae4ee56f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[0.0, 0.0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out_t…"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ipyleaflet\n",
+    "\n",
+    "m = ipyleaflet.Map()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "85f4f957",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Installs geemap package\n",
+    "import subprocess\n",
+    "\n",
+    "try:\n",
+    "    import geemap\n",
+    "except ImportError:\n",
+    "    print(\"Installing geemap ...\")\n",
+    "    subprocess.check_call([\"python\", \"-m\", \"pip\", \"install\", \"geemap\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "53fec8e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c816877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# geemap.update_package()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0ef2d11",
+   "metadata": {},
+   "source": [
+    "## Create an interactive map\n",
+    "The default basemap is Google Maps. Additional basemaps can be added using the Map.add_basemap() function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "65a4ecce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "                \n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "                    \n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "91bbe5fe6e7746cc9559b3fe20a9650f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[0, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=SearchDataGUI(childr…"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Map = geemap.Map()  # center=[40,-100], zoom=4)\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e2584b2",
+   "metadata": {},
+   "source": [
+    "## Visualizing Landsat Data with folium\n",
+    "\n",
+    "Now that we have fetched the Landsat data, let's visualize it on an interactive map using `folium`. We will display the Land Surface Temperature (LST) layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5573252",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import folium\n",
+    "from folium import plugins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "834eeebe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a method for displaying Earth Engine image tiles on a folium map.\n",
+    "def add_ee_layer(self, ee_object, vis_params, name):\n",
+    "\n",
+    "    try:\n",
+    "        tile_layer = None\n",
+    "        # display ee.Image()\n",
+    "        if isinstance(ee_object, ee.image.Image):\n",
+    "            map_id_dict = ee.Image(ee_object).getMapId(vis_params)\n",
+    "            tile_layer = folium.raster_layers.TileLayer(\n",
+    "                tiles=map_id_dict[\"tile_fetcher\"].url_format,\n",
+    "                attr=\"Google Earth Engine\",\n",
+    "                name=name,\n",
+    "                overlay=True,\n",
+    "                control=True,\n",
+    "            )\n",
+    "            tile_layer.add_to(self)\n",
+    "\n",
+    "        # display ee.ImageCollection()\n",
+    "        elif isinstance(ee_object, ee.imagecollection.ImageCollection):\n",
+    "            ee_object_new = ee_object.mosaic()\n",
+    "            map_id_dict = ee.Image(ee_object_new).getMapId(vis_params)\n",
+    "            tile_layer = folium.raster_layers.TileLayer(\n",
+    "                tiles=map_id_dict[\"tile_fetcher\"].url_format,\n",
+    "                attr=\"Google Earth Engine\",\n",
+    "                name=name,\n",
+    "                overlay=True,\n",
+    "                control=True,\n",
+    "            )\n",
+    "            tile_layer.add_to(self)\n",
+    "\n",
+    "        # display ee.Geometry()\n",
+    "        elif isinstance(ee_object, ee.geometry.Geometry):\n",
+    "            folium.GeoJson(\n",
+    "                data=ee_object.getInfo(), name=name, overlay=True, control=True\n",
+    "            ).add_to(self)\n",
+    "\n",
+    "        # display ee.FeatureCollection()\n",
+    "        elif isinstance(ee_object, ee.featurecollection.FeatureCollection):\n",
+    "            ee_object_new = ee.Image().paint(ee_object, 0, 2)\n",
+    "            map_id_dict = ee.Image(ee_object_new).getMapId(vis_params)\n",
+    "            tile_layer = folium.raster_layers.TileLayer(\n",
+    "                tiles=map_id_dict[\"tile_fetcher\"].url_format,\n",
+    "                attr=\"Google Earth Engine\",\n",
+    "                name=name,\n",
+    "                overlay=True,\n",
+    "                control=True,\n",
+    "            )\n",
+    "        tile_layer.add_to(self)\n",
+    "\n",
+    "        print(tile_layer)\n",
+    "        return tile_layer\n",
+    "    except:\n",
+    "        print(\"Could not display {}\".format(name))\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "# Add EE drawing method to folium.\n",
+    "folium.Map.add_ee_layer = add_ee_layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c670564-eaa5-47cf-87c6-0453dc64dde6",
+   "metadata": {
+    "noteable": {
+     "cell_type": "code"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get Landsat collection first image\n",
+    "# ex_image = landsat_coll.first()\n",
+    "\n",
+    "# Visualization parameters\n",
+    "cmap1 = [\"blue\", \"cyan\", \"green\", \"yellow\", \"red\"]\n",
+    "cmap2 = [\"F2F2F2\", \"EFC2B3\", \"ECB176\", \"E9BD3A\", \"E6E600\", \"63C600\", \"00A600\"]\n",
+    "\n",
+    "\n",
+    "# Add the Earth Engine layers to the folium map\n",
+    "layers = [\n",
+    "    {\n",
+    "        \"band\": \"TPW\",\n",
+    "        \"vis_params\": {\"min\": 0, \"max\": 60, \"palette\": cmap1},\n",
+    "        \"name\": \"TCWV\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"band\": \"TPWpos\",\n",
+    "        \"vis_params\": {\"min\": 0, \"max\": 9, \"palette\": cmap1},\n",
+    "        \"name\": \"TCWVpos\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"band\": \"FVC\",\n",
+    "        \"vis_params\": {\"min\": 0, \"max\": 1, \"palette\": cmap2},\n",
+    "        \"name\": \"FVC\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"band\": \"EM\",\n",
+    "        \"vis_params\": {\"min\": 0.9, \"max\": 1.0, \"palette\": cmap1},\n",
+    "        \"name\": \"Emissivity\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"band\": \"B10\",\n",
+    "        \"vis_params\": {\"min\": 290, \"max\": 320, \"palette\": cmap1},\n",
+    "        \"name\": \"TIR BT\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"band\": \"LST\",\n",
+    "        \"vis_params\": {\"min\": 290, \"max\": 320, \"palette\": cmap1},\n",
+    "        \"name\": \"LST\",\n",
+    "    },  # ,\n",
+    "    # {'band': 'RGB', 'vis_params': {'bands': ['SR_B4', 'SR_B3', 'SR_B2'], 'min': 0, 'max': 0.3}, 'name': 'RGB'}\n",
+    "]\n",
+    "\n",
+    "# https://stackoverflow.com/questions/64792041/white-gap-between-python-folium-map-and-jupyter-notebook-cell\n",
+    "# Create a folium map object\n",
+    "# from branca.element import Figure\n",
+    "# fig = Figure(height=500) #width=600,\n",
+    "my_map = folium.Map(location=[40.2, -8.6], zoom_start=10, height=500)\n",
+    "# fig.add_child(my_map)\n",
+    "\n",
+    "tile_layers = []\n",
+    "for layer in layers:\n",
+    "    # tile_layer = my_map.add_ee_layer(ex_image.select(layer['band']), layer['vis_params'], layer['name'])\n",
+    "    tile_layer = my_map.add_ee_layer(\n",
+    "        landsat_coll.select(layer[\"band\"]), layer[\"vis_params\"], layer[\"name\"]\n",
+    "    )\n",
+    "    if tile_layer:\n",
+    "        tile_layers.append(tile_layer)\n",
+    "\n",
+    "# Add WmsTileLayers to time control.\n",
+    "time = plugins.TimestampedWmsTileLayers(tile_layers)\n",
+    "time.add_to(my_map)\n",
+    "\n",
+    "# Add a layer control panel to the map.\n",
+    "my_map.add_child(folium.LayerControl())\n",
+    "\n",
+    "# Display the map\n",
+    "my_map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "965f8699",
+   "metadata": {},
+   "source": [
+    "## Explanation of Layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "957537ee-6a2a-4103-949a-abcb786fa009",
+   "metadata": {
+    "noteable": {
+     "cell_type": "markdown"
+    }
+   },
+   "source": [
+    "### TCWV (Total Column Water Vapor)\n",
+    "This layer represents the Total Column Water Vapor (TCWV). Water vapor plays a crucial role in the Earth's energy balance, and its distribution is essential for weather forecasting and climate modeling. In the context of urban areas, understanding TCWV can provide insights into urban heat island effects and local climate variations.\n",
+    "\n",
+    "### TCWVpos\n",
+    "This layer is a positive representation of the TCWV. It emphasizes areas with higher water vapor concentrations, which can be particularly relevant in urban climate studies to identify areas of increased humidity or potential heat stress.\n",
+    "\n",
+    "### FVC (Fractional Vegetation Cover)\n",
+    "The Fractional Vegetation Cover (FVC) layer provides a measure of the proportion of ground covered by vegetation. In urban areas, vegetation can play a significant role in mitigating the urban heat island effect, providing shade, and improving air quality. Thus, understanding FVC can help in urban planning and sustainability efforts.\n",
+    "\n",
+    "### Emissivity\n",
+    "Emissivity represents the efficiency of a surface in emitting thermal radiation. Different surfaces, such as buildings, roads, and vegetation, have different emissivity values. In urban areas, understanding surface emissivity can help in assessing the thermal properties of various surfaces and their contribution to local temperature variations.\n",
+    "\n",
+    "### TIR BT (Thermal Infrared Brightness Temperature)\n",
+    "This layer represents the brightness temperature in the thermal infrared spectrum. It provides a direct measure of the surface temperature, which is crucial for understanding urban heat islands and local temperature variations.\n",
+    "\n",
+    "### LST (Land Surface Temperature)\n",
+    "The Land Surface Temperature (LST) layer provides a measure of the temperature of the Earth's surface. In urban areas, LST can vary significantly due to factors like urban heat islands, surface materials, and vegetation cover. Understanding LST is essential for urban climate studies and health assessments.\n",
+    "\n",
+    "### RGB\n",
+    "This layer provides a true-color representation of the area using the Red, Green, and Blue bands. It gives a visual context to the other layers and helps in understanding the spatial distribution of features like vegetation, water bodies, and urban infrastructure.\n",
+    "\n",
+    "The methodologies and significance of these layers are discussed in detail in the paper titled \"[An Open-Source Tool for Automated Quality Assessment of Landsat Surface Temperature over Urban Areas](https://www.mdpi.com/2072-4292/12/9/1471/pdf?version=1589365556)\" by Lorenzo Bigagli, Massimiliano Nole, Simone Mantovani, and Mattia Crespi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "611d6d90-294a-4936-8f88-5b4c8475439d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-10T11:01:24.554244+00:00",
+     "start_time": "2023-09-10T11:01:23.934683+00:00"
+    },
+    "noteable": {
+     "cell_type": "code",
+     "output_collection_id": "2f384f52-38f3-4504-9796-49624dcb58b9"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  },
+  "noteable-chatgpt": {
+   "create_notebook": {
+    "openai_conversation_id": "5b206a8d-1381-5710-8ef9-6ea4c441d9ee",
+    "openai_ephemeral_user_id": "6d6b62e2-4293-50fb-bd1f-908ad0cb15a1",
+    "openai_subdivision1_iso_code": "PT-14"
+   }
+  },
+  "selected_hardware_size": "small"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Development / CI tooling. Pinned exactly so local runs and CI cannot drift:
+# an unpinned linter turns CI red on its own release schedule, with no commit.
+#
+# black MUST carry the [jupyter] extra. Bare black silently skips .ipynb files,
+# so examples/example_1.ipynb would be formatted locally and unchecked in CI.
+black[jupyter]==26.5.1
+flake8==7.3.0

--- a/tests/test_aster_bare_emiss.py
+++ b/tests/test_aster_bare_emiss.py
@@ -36,7 +36,5 @@ def test_emiss_bare_band10():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_broadband_emiss.py
+++ b/tests/test_broadband_emiss.py
@@ -37,7 +37,5 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_cloudmask.py
+++ b/tests/test_cloudmask.py
@@ -55,9 +55,7 @@ def test_sr():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"
 
 
@@ -76,9 +74,7 @@ def test_toa():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"
 
 

--- a/tests/test_compute_emissivity.py
+++ b/tests/test_compute_emissivity.py
@@ -38,7 +38,5 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_compute_fvc.py
+++ b/tests/test_compute_fvc.py
@@ -36,9 +36,7 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"
 
 

--- a/tests/test_compute_ndvi.py
+++ b/tests/test_compute_ndvi.py
@@ -36,7 +36,5 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_landsat_lst.py
+++ b/tests/test_landsat_lst.py
@@ -36,7 +36,5 @@ def test_compute_LST():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_ncep_tpw.py
+++ b/tests/test_ncep_tpw.py
@@ -36,7 +36,5 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"

--- a/tests/test_smw_algorithm.py
+++ b/tests/test_smw_algorithm.py
@@ -36,7 +36,5 @@ def test_add_band():
 
     # Assert that the result matches the expected output
     # (this is a placeholder, adjust as needed)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output}, \
+    assert result == expected_output, f"Expected {expected_output}, \
         but got {result}"


### PR DESCRIPTION
Phase 1 of the refresh. **Goal: green CI. No behavioural change.**

Baseline this is measured against: `05e08cd` (2023-10-19). Full pre-refresh
measurements are on the `refresh/00-baseline` branch in `.refresh/baseline.md`.

## Why CI was red

Three independent causes:

1. **Deprecated actions.** Both workflows used `actions/checkout@v2`,
   `setup-python@v2`, `cache@v2` — Node 16 actions that GitHub-hosted runners no
   longer execute. The job died before any project code ran.
2. **flake8** — 2 errors, both at `ee_lst/landsat_lst.py:95` (E261, E262).
3. **black --check** — 11 files would be reformatted.

Root cause behind 2 and 3: `ci.yml` ran `pip install flake8 black` unpinned, so
any new release could turn CI red with no commit.

## What changed

| Commit | |
|---|---|
| `8838b66` | `ci:` bump actions, pin Python 3.13, pin linters via new `requirements-dev.txt` |
| `9e7b270` | `fix:` correct inline comment style at `landsat_lst.py:95` |
| `ff42920` | `style:` black on Python sources |
| `75bc55e` | `style:` black on `examples/example_1.ipynb` |
| `b09d1ab` | `ci:` move actions to their node24 majors |

Formatting is split from the lint fix, and the notebook is split from the Python
files, so each diff is reviewable on its own.

### Notable decisions

- **Actions land on `checkout@v7`, `setup-python@v7`, `cache@v6`, not v4/v5.**
  The first CI run on this branch warned that v4/v5 target Node 20, which is
  itself deprecated and being force-run on Node 24 — the same failure mode that
  made this repo's CI red originally, one cycle later. Each of these majors
  declares `using: node24`, verified against their `action.yml` at the pinned
  tag. Since the runner already forces node24, the runtime does not change; only
  the action code does. The annotation is now gone.
- **Python pinned to `3.13`, not `'3.x'`.** A floating version is why a green
  build turns red months later with no commit. 3.13 matches the version the
  baseline was measured on, so CI and local agree.
- **`black[jupyter]==26.5.1`, not bare `black`.** Bare black silently skips
  `.ipynb`, which would leave the notebook formatted locally but unchecked in
  CI — the exact drift the pinning exists to prevent.
- **The notebook diff is huge (1561 lines) and that is expected.** black rewrites
  `.ipynb` JSON with nbformat's 1-space indent; the file was stored with 2-space.
  ~96% of lines change, almost all JSON re-indentation. Only 7 of 25 cells have
  any source change. One-time cost.

## Verification

`git diff --stat` is not a meaningful safety check on a reformat this size, so
equivalence was established structurally instead.

- **All 24 `.py` files** parsed with `ast.parse` before and after, compared via
  `ast.dump` — **24/24 identical syntax trees**. No coefficient, band mapping or
  expression can have moved (guardrail 2).
- **Notebook**: 25 cells → 25; `nbformat` 4.5 unchanged; outputs, execution
  counts and cell metadata identical for every cell; **7/7 changed code cells
  AST-identical**.

CI steps also run in a clean venv on Python 3.13, using the literal commands from
`ci.yml`:

```
pip install -r requirements.txt && pip install -r requirements-dev.txt   OK
flake8 ee_lst/ tests/ examples/ validation/                              exit 0
black --check ee_lst/ tests/ examples/ validation/                       exit 0  (25 files)
```

Also confirmed: `import ee_lst.landsat_lst` OK; `LANDSAT_BANDS` and
`SMW_COEFFICIENTS` still have exactly `L4 L5 L7 L8 L9`.

**CI on this PR is green with zero annotations.**

## Out of scope here

- **The pytest step stays commented out.** All 10 test functions currently fail
  (8 call functions that don't exist, 2 call live Earth Engine). Phase 3.
- **`pip install .` is still broken** — `pyCrypto` cannot build on Python 3.13.
  Note this CI installs `requirements.txt`, which never exercises `setup.py`, so
  it would not have caught that and still won't. Phase 2 adds the smoke test.
- **Pre-existing bug in `example_1.ipynb` cell 20**: the trailing
  `tile_layer.add_to(self)` sits at the same indent as the `if`/`elif` chain, so
  the Image branches add the layer twice and the Geometry branch raises
  `AttributeError` into a bare `except`. Present identically before and after the
  reformat. Left alone — `examples/` is phase 4, and mixing a logic fix into a
  formatting commit would violate guardrail 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
