### PR TITLE
Phase 2: make the package installable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Python 3 for LST Refactoring",
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.9",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/python:1": {},
@@ -9,7 +9,7 @@
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
-	"postCreateCommand": "pip install numpy pandas rasterio satpy dask google-api-python-client pyCrypto earthengine-api",
+	"postCreateCommand": "pip install -e . -r requirements.txt -r requirements-dev.txt",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,49 @@ jobs:
     # - name: Run tests
     #   run: |
     #     python -m pytest tests/
+
+  # The lint job installs requirements.txt and never touches setup.py, so it
+  # cannot catch a broken install_requires - that is exactly how the pyCrypto
+  # breakage survived. This job installs the package the way a user would.
+  install:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v7
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install the package into a clean venv
+      run: |
+        python -m venv /tmp/smoke
+        /tmp/smoke/bin/python -m pip install --upgrade pip
+        /tmp/smoke/bin/pip install .
+
+    - name: Import smoke test
+      # Run from outside the repo: importing from the source tree would pass
+      # even if the package were built or declared wrongly.
+      working-directory: /tmp
+      run: |
+        /tmp/smoke/bin/python -c "
+        import ee_lst.landsat_lst as m
+        assert 'site-packages' in m.__file__, m.__file__
+        print('imported installed package:', m.__file__)
+        "
+
+    - name: Package must not ship an 'examples' module
+      # A bare find_packages() used to install examples/ as a top-level package.
+      working-directory: /tmp
+      run: |
+        /tmp/smoke/bin/python -c "
+        import importlib.util as u, sys
+        assert u.find_spec('examples') is None, 'examples/ leaked into the wheel'
+        print('no top-level examples package: OK')
+        "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,25 @@
-google-api-python-client
-pycryptodome
+# Full working environment for this repo: the library plus everything the
+# validation harness and the examples need.
+#
+# The library alone needs far less - see install_requires in setup.py.
+# `pip install .` is the minimal install; this file is the superset.
+
+# --- the ee_lst package itself ------------------------------------------------
+# Keep in sync with install_requires in setup.py.
 earthengine-api
+
+# --- imported by name in validation/example_1_service_account.py --------------
+# Both also arrive transitively via earthengine-api, but the code imports them
+# directly (googleapiclient.discovery, google.oauth2.service_account), so they
+# are declared rather than relied on as a transitive accident.
+google-api-python-client
 google-auth
+
+# --- validation/geotiffs_comparison.py ----------------------------------------
+numpy
 rasterio
+
+# --- examples/example_1.py ----------------------------------------------------
+# Was missing entirely: the example the README tells people to run imports
+# folium, and nothing installed it.
+folium

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,39 @@
 from setuptools import setup, find_packages
 
+# Was a backslash continuation, which baked 8 literal spaces into the middle of
+# the published description ("...Surface        Temperature...").
+DESCRIPTION = "Python library for Landsat Surface Temperature with Google Earth Engine"
+
 setup(
     name="ee_lst",
     version="0.1.0",
-    description="Python library for Landsat Surface\
-        Temperature with Google Earth Engine",
+    description=DESCRIPTION,
     author="Nelson Luna Silvestre",
     author_email="lunasilvestre@mailbox.org",
     url="https://github.com/lunasilvestre/ee_lst",
-    packages=find_packages(),
+    # include= is load-bearing. A bare find_packages() also matches examples/,
+    # which has an __init__.py, so `pip install ee_lst` would drop a top-level
+    # `examples` package into site-packages.
+    packages=find_packages(include=["ee_lst*"]),
     install_requires=[
-        "numpy",
-        "rasterio",
-        "google-api-python-client",
-        "pyCrypto",
-        "earthengine-api"
+        # ee_lst imports only `ee` (plus stdlib os). earthengine-api pulls the
+        # rest of the stack transitively: google-api-python-client,
+        # google-auth, google-auth-httplib2, google-cloud-storage, httplib2,
+        # requests, cryptography.
+        #
+        # Deliberately NOT listed:
+        #   numpy, rasterio - used only by validation/geotiffs_comparison.py
+        #   folium          - used only by examples/example_1.py
+        #   pyCrypto        - vestigial; nothing under ee/ or google/ imports
+        #                     Crypto, and it cannot build on Python 3.11+
+        # All of those live in requirements.txt instead.
+        "earthengine-api",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )


### PR DESCRIPTION
Phase 2 of the refresh. **Goal: `pip install .` works. No behavioural change to the library.**

## The bug

`pip install .` failed outright — `setup.py` required `pyCrypto`, abandoned and
unbuildable on Python 3.11+ (its C extension includes `longintrepr.h`, made
private in CPython 3.11):

```
src/_fastmath.c:33:10: fatal error: longintrepr.h: No such file or directory
ERROR: Failed building wheel for pyCrypto
```

Anyone following the README (`pip install . && pip install -r requirements.txt`)
hit this on the first half.

## The plan said swap it; testing said delete it

`REFRESH_PLAN.md` step 1 called for `pyCrypto` → `pycryptodome`. That would have
worked, but it turns out the dependency isn't needed at all — it's vestigial from
an older `earthengine-api` that signed service-account JWTs with PyCrypto.

- nothing under `ee/` or `google/` in site-packages references `Crypto`
- the service-account path resolves through `google.oauth2` + `cryptography`,
  which arrive with the Google stack regardless
- `ee_lst` imports cleanly with `pycryptodome` absent

`ee_lst/` imports only `ee` and stdlib `os`. So `install_requires` is now just
`earthengine-api`.

### Verified four ways, not assumed

| test | result |
|---|---|
| Static: every import in `ee_lst/*.py`, indented included | only `ee`, `os`, `ee_lst.*`; no `importlib`/`__import__`/`exec` |
| Full venv, `numpy`+`rasterio`+`Crypto` blocked at import | 10 modules, 25 public-function calls — all pass |
| Negative control: block `ee_lst` itself | fails as expected, so the blocker is real |
| Clean venv, only `earthengine-api` installed | same 25 calls — all pass |

`numpy`/`rasterio` are used only by `validation/geotiffs_comparison.py`, `folium`
only by `examples/example_1.py`. None belong to the library, so they live in
`requirements.txt`, now documented as the superset environment rather than a
second disagreeing list.

## Two more packaging defects found while here

**`find_packages()` was shipping `examples/`.** With no arguments it also matched
`examples/` (which has an `__init__.py`), so `pip install ee_lst` dropped a
top-level `examples` package into site-packages — containing the module whose
`from modules.landsat_lst import ...` is itself broken. Confirmed from the
`build/lib/` tree of a previous install. Now scoped with `include=["ee_lst*"]`.
Independent of whether phase 4 keeps `examples/__init__.py`.

**`description` had a backslash continuation**, baking 8 literal spaces into the
published metadata:

```
before: 'Python library for Landsat Surface        Temperature with Google Earth Engine'
after:  'Python library for Landsat Surface Temperature with Google Earth Engine'
```

**`folium` was in neither `setup.py` nor `requirements.txt`**, so
`examples/example_1.py` could not have run even after phase 4 fixes its import
path. Added — phase 4's gate depended on it.

## Gate

`pip install .` in a fresh venv, both versions:

| | 3.12.13 | 3.13.5 |
|---|---|---|
| `pip install .` | OK | OK |
| import resolves to site-packages (run from `/tmp`) | OK | OK |
| no top-level `examples` module | OK | OK |
| `numpy` / `rasterio` / `Crypto` absent | OK | OK |
| 10 modules + 25 calls against the **installed** package | OK | OK |

`requirements.txt` still installs cleanly (folium 0.20.0, rasterio 1.5.0).
`flake8` and `black --check` both exit 0 across the CI paths; `setup.py` is now
black-clean too, though it sits outside the linted paths.

## What changed

| Commit | |
|---|---|
| `df78571` | `fix(packaging):` declare the dependencies ee_lst actually has |
| `855e344` | `fix(devcontainer):` bump off Python 3.9, install from the repo's own files |
| `4cbc453` | `ci:` add an install smoke test on 3.12 and 3.13 |

The new `install` job is the regression guard: the lint job installs
`requirements.txt` and never touches `setup.py`, which is exactly how the
pyCrypto breakage survived — `pip install -r requirements.txt` worked while
`pip install .` didn't, and CI only ran the former.

**Scope note:** the plan lists a Python version matrix as out of scope, but phase
2's gate explicitly requires both 3.12 and 3.13. The matrix is confined to the
install job; the lint job stays single-version and the test suite is untouched.

## Deliberately not done

- **No `python_requires`.** Classifiers now claim 3.12/3.13, so pip will still
  install on older versions and let `earthengine-api`'s own floor govern. Adding
  a bound is a real decision about who gets stranded — worth doing, not silently.
- **`setup.py` not added to the flake8/black paths.** It's clean, but widening
  CI's lint scope isn't this phase's job.
- **`requirements.txt` kept as an explicit list** rather than `-e .`, so phase
  5's Dockerfile rewrite doesn't inherit a layer-caching problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
