### PR TITLE
Phase 6: documentation and close-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # `ee_lst`
 
-![CI/CD Workflow](https://github.com/lunasilvestre/ee_lst/actions/workflows/ci.yml/badge.svg) [![Refactoring Validation](https://github.com/lunasilvestre/ee_lst/actions/workflows/refactoring_validation.yml/badge.svg)](https://github.com/lunasilvestre/ee_lst/actions/workflows/refactoring_validation.yml)
+[![CI](https://github.com/lunasilvestre/ee_lst/actions/workflows/ci.yml/badge.svg)](https://github.com/lunasilvestre/ee_lst/actions/workflows/ci.yml) [![Refactoring Validation](https://github.com/lunasilvestre/ee_lst/actions/workflows/refactoring_validation.yml/badge.svg)](https://github.com/lunasilvestre/ee_lst/actions/workflows/refactoring_validation.yml)
+
+Tested on Python 3.12 and 3.13.
 
 `ee_lst` is a Python package designed to provide functionalities related to Land Surface Temperature (LST) computation using the Landsat series of satellites. This package expands the use of the original Google Earth Engine (GEE) code, initially crafted in JavaScript by [Sofia Ermida](https://github.com/sofiaermida). Transitioning to Python not only grants more versatility to the code but also broadens its accessibility. The original repository by Sofia Ermida can be accessed [here](https://github.com/sofiaermida/Landsat_SMW_LST).
 
 ## Table of Contents
 
 - [Installation](#installation)
+- [Authentication](#authentication)
 - [Usage](#usage)
 - [Refactoring Validation](#refactoring-validation)
 - [Examples](#examples)
@@ -19,23 +22,78 @@
 
 ## Installation
 
-To install the `ee_lst` package, follow these steps:
+Requires Python 3.12 or 3.13.
 
-```
-# Clone the repository
+```bash
 git clone https://github.com/lunasilvestre/ee_lst.git
-
-# Navigate to the repository directory
 cd ee_lst
 
-# Install the package and its dependencies
-pip install . && pip install -r requirements.txt
+# The library. This is all you need to use ee_lst.
+pip install .
 ```
 
+`ee_lst` itself depends only on `earthengine-api`, which brings the Google client
+stack with it.
+
+Two further requirement files cover things the library itself does not need:
+
+```bash
+# Adds what the examples and the validation harness use:
+# numpy, rasterio, folium
+pip install -r requirements.txt
+
+# Adds the linters and test runner, pinned to the versions CI uses
+pip install -r requirements-dev.txt
+```
+
+## Authentication
+
+`ee_lst` does not configure credentials for you, and importing it does not touch
+your environment. Authenticate with Earth Engine however you normally would,
+before calling into the library:
+
+```bash
+# Interactive, once per machine
+earthengine authenticate
+```
+
+```bash
+# Or point Application Default Credentials at a service account key
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your-key.json
+```
+
+You can also call `ee.Initialize()` yourself with your own credentials first —
+`fetch_landsat_collection` will use the already-initialized session.
+
+Either way the account must be **registered with an Earth Engine project**.
+Credentials alone are not enough; without registration Earth Engine returns
+`Not signed up for Earth Engine or project is not registered`.
 
 ## Usage
 
-For using this package with Docker, especially regarding handling credentials, see [this guide](./.github/workflows/README.md).
+```python
+import ee
+from ee_lst.landsat_lst import fetch_landsat_collection
+
+geometry = ee.Geometry.Rectangle([-8.91, 40.0, -8.3, 40.4])
+
+collection = fetch_landsat_collection(
+    "L8",              # one of L4, L5, L7, L8, L9
+    "2022-05-15",      # start date
+    "2022-05-31",      # end date
+    geometry,
+    True,              # use_ndvi: dynamic emissivity from NDVI
+)
+
+image = collection.first()
+lst = image.select("LST")   # land surface temperature, kelvin
+```
+
+Each image in the returned collection carries the added bands `NDVI`, `FVC`,
+`TPW`, `TPWpos`, `EM`, `LST` and `TIMESTAMP` alongside the source bands.
+
+For running this package under Docker, particularly around credential handling,
+see [this guide](./.github/workflows/README.md).
 
 
 ## Refactoring Validation
@@ -69,13 +127,18 @@ For insights into our CI/CD procedures and other workflows, peruse the [workflow
 
 ## Testing
 
-Tests reside in the tests directory. To initiate them:
-
-```
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
 pytest tests/
 ```
 
-For a deeper dive into testing, check out the [tests README](./tests/README.md)
+The suite mocks the Earth Engine client, so it runs in about a second and needs
+**no credentials and no network access**. It checks the things that regress
+silently under refactoring — per-satellite band selection, scale factors,
+coefficient tables, output band names — rather than pixel values. Verifying the
+numbers is the [validation harness](./validation/README.md)'s job.
+
+For a deeper dive, see the [tests README](./tests/README.md).
 
 ## Reference
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -23,17 +23,60 @@ This directory (`validation`) is dedicated to tools and resources required for t
    
 3. **Image Comparison**:
    - Run `geotiffs_comparison.py` to compare the images.
-   - This script evaluates size and pixel value differences.
-   - Detailed differences are saved and a summary is printed.
-   
+   - It evaluates size and pixel value differences, printing a summary per band.
+
 4. **Criteria for Validation**:
-   - A size difference threshold (e.g., 0.5%) is set.
-   - Pixel value differences should be minimal or within acceptable bounds.
-   
+   - **Pixel values must match exactly.** Mean, max and min difference must all be
+     `0`. There is no numerical tolerance and there should not be one — both
+     implementations send the same graph to the same Earth Engine servers, so any
+     nonzero delta means the port has diverged.
+   - Image *size* has a 0.5% tolerance, since the two clients can request very
+     slightly different windows.
+   - Every band must be present on **both** sides. A band exported by only one
+     implementation is a band nobody checked.
+
 5. **Integration with CI/CD**:
    - The GitHub workflow `refactoring_validation.yml` automates this validation.
    - It manages Docker containers, generates outputs, and runs the comparison.
+   - Triggers: every push to `main`, monthly on the 1st, and `workflow_dispatch`
+     for on-demand runs.
    - Workflow failures indicate discrepancies in refactoring.
+
+## How the comparison can fail
+
+`geotiffs_comparison.py` exits non-zero, and says which of these applies, when:
+
+- a download directory is missing — the container never ran;
+- **nothing was compared** — the directories exist but hold no matching pair.
+  This used to exit `0`: the script looped over an empty directory, did nothing,
+  and reported success. A validation job that cannot fail is worse than none;
+- the two sides disagree about which bands exist, in *either* direction;
+- any band differs by any amount.
+
+The both-directions check is not hypothetical. A real run had the JavaScript
+container export 3 of 8 bands while Python exported all 8; because the unmatched
+files were the extra ones, a one-directional check saw nothing wrong and the job
+passed having validated well under half the output.
+
+## Reproducibility
+
+`Dockerfile.landsat_lst` pins the upstream clone to
+`65fd1ae9c752b6e3f738405495bcb1b5c773cf4d` ("Update to process Landsat9",
+2023-08-02) and asserts the SHA after checkout. Upstream is archived, and
+`modify_files.sh` sed-edits a hardcoded list of module filenames, so an
+unpinned clone would let a reorganisation upstream break the harness silently.
+
+`modify_files.sh` rewrites 8 of the 10 upstream modules. That is correct, not an
+omission: `cloudmask.js` and `compute_FVC.js` mention the Code Editor require
+path only inside their header comments and contain no real `require()` calls.
+
+## Credentials
+
+The service account key is mounted at run time with `-v`; no Dockerfile `COPY`s
+it and it is absent from every image layer. The repo's `.dockerignore` also keeps
+it out of the build context entirely — the workflow writes
+`.gee-sa-priv-key.json` into the repo root *before* building, and the build
+context is the repo root.
 
 ## Note
 The validation process ensures library integrity during and after refactoring. It's crucial to maintain and expand these validation tools as the library evolves.

--- a/validation/geotiffs_comparison.py
+++ b/validation/geotiffs_comparison.py
@@ -74,36 +74,39 @@ if __name__ == "__main__":
         if not os.path.isdir(d):
             raise SystemExit(f"{d} does not exist - did the container run?")
 
+    tifs1 = {f for f in os.listdir(dir1) if f.endswith(".tif")}
+    tifs2 = {f for f in os.listdir(dir2) if f.endswith(".tif")}
+
     compared = 0
-    skipped = []
-
-    for filename in sorted(os.listdir(dir1)):
-        if filename.endswith(".tif"):
-            img1_path = os.path.join(dir1, filename)
-            img2_path = os.path.join(dir2, filename)
-
-            if os.path.exists(img2_path):
-                print(f"Comparing {filename}...")
-                compare_images(img1_path, img2_path)
-                compared += 1
-                print("-" * 40)
-            else:
-                skipped.append(filename)
-                print(f"Warning: {filename} not found in {dir2}. Skipping comparison.")
+    for filename in sorted(tifs1 & tifs2):
+        print(f"Comparing {filename}...")
+        compare_images(os.path.join(dir1, filename), os.path.join(dir2, filename))
+        compared += 1
+        print("-" * 40)
 
     # Without this the script exits 0 when it compared nothing at all - an empty
     # download directory, a container that produced no output, a rename upstream.
     # A validation job that cannot fail is worse than no validation job.
     if compared == 0:
         raise SystemExit(
-            f"No GeoTIFFs were compared. {dir1} contained no .tif with a "
-            f"counterpart in {dir2}; nothing was validated."
+            f"No GeoTIFFs were compared. No .tif in {dir1} had a counterpart "
+            f"in {dir2}; nothing was validated."
         )
 
-    if skipped:
+    # Checked in BOTH directions on purpose. A real run showed the JavaScript
+    # container exporting only 3 of 8 bands while Python exported all 8: the
+    # unmatched files were the *extra* ones, so a one-directional check saw
+    # nothing wrong and the job passed having validated well under half the
+    # output. Whichever side comes up short, it went unvalidated.
+    unmatched = []
+    if tifs1 - tifs2:
+        unmatched.append(f"only in {dir1}: {', '.join(sorted(tifs1 - tifs2))}")
+    if tifs2 - tifs1:
+        unmatched.append(f"only in {dir2}: {', '.join(sorted(tifs2 - tifs1))}")
+    if unmatched:
         raise SystemExit(
-            f"{len(skipped)} file(s) present in {dir1} had no counterpart in "
-            f"{dir2} and went unchecked: {', '.join(skipped)}"
+            f"Compared {compared} band(s), but the two sides do not match, so "
+            f"some output went unvalidated - " + "; ".join(unmatched)
         )
 
-    print(f"OK: {compared} GeoTIFF(s) compared, all pixel-identical.")
+    print(f"OK: all {compared} band(s) present on both sides, pixel-identical.")


### PR DESCRIPTION
Phase 6 of the refresh. **Documentation and close-out.**

## The refresh is numerically faithful — confirmed against live Earth Engine

The validation workflow runs on every push to `main`, so merging phase 3 triggered
a full JS-vs-Python pixel diff. It passed:

```
Comparing Emissivity.tif...  Size difference: 0.07%  Mean 0.00  Max 0.00  Min 0.00
Comparing RGB.tif...         Size difference: 0.07%  Mean 0.00  Max 0.00  Min 0.00
Comparing LST.tif...         Size difference: 0.07%  Mean 0.00  Max 0.00  Min 0.00
```

Zero difference on every compared band, including LST itself. Guardrail 2 holds.

## But that run should not have passed

It compared **3 of 8 bands**. The JavaScript container reported `TCWV.tif not
found`, and likewise `TCWVpos`, `FVC`, `TIR_BT`, `LST_Celsius_Raw`. Python
exported all 8.

The comparison iterated the JavaScript side and checked each file had a Python
counterpart. All 3 did. So it compared 3, found them identical, and exited 0 —
having silently validated well under half the output. **The unmatched files were
the extra ones**, and a one-directional check never looks at those.

Phase 5's fix did not catch this: it guards against comparing *nothing*, not
against comparing *some*. The check is now symmetric — a band present on one side
and not the other fails the run, whichever side is short. Verified against a
fixture reproducing that exact 3-vs-8 split: exits 1, naming the five unvalidated
bands.

**Consequence worth flagging:** the next validation run will likely go red, on a
pre-existing partial-export problem rather than anything this refresh introduced.
That is the point — it was always failing to validate 5 bands, it just never said
so. The underlying cause looks like an Earth Engine export/download race in
`example_1_node.js` (downloads polled ~90s apart, some tasks not finished in
time), which is a separate fix.

## README

- Install was `pip install . && pip install -r requirements.txt`, conflating two
  things. `pip install .` is now sufficient for the library; `requirements.txt`
  adds what only the examples and validation need; `requirements-dev.txt` adds the
  pinned linters and test runner.
- States supported versions: Python 3.12 and 3.13.
- **New Authentication section.** Phase 4 removed the import-time write to
  `GOOGLE_APPLICATION_CREDENTIALS`, so callers now supply credentials themselves —
  a user-visible change that was undocumented. It also records that credentials
  alone are not enough: the account must be registered with an Earth Engine
  project, which is the first error anyone following this README will hit.
- The Usage section contained no usage, only a link. Added a worked example with
  the real signature and the bands the result carries.
- CI badge is now a link, as the validation badge already was.

## validation/README.md

- *"Pixel value differences should be minimal or within acceptable bounds"* was
  wrong, and misleading in the direction that matters. **There is no tolerance** —
  mean, max and min must all be exactly 0. Only size has one, at 0.5%.
- Documents the pinned upstream SHA, why `modify_files.sh` covering 8 of 10
  modules is correct rather than an omission, the `.dockerignore`, and the
  workflow's triggers.

## Dependabot PRs — verified, ready to merge

All three touch only `package-lock.json`, all transitive under
`@google/earthengine`. CI passing would not have proven much, since CI never
builds the Node container — so I built it against each lockfile on the **new**
`node:20` + pinned-clone image:

| PR | | build |
|---|---|---|
| #3 | node-forge 1.3.1 → 1.3.2 | OK (v20.20.2) |
| #4 | jws 4.0.0 → 4.0.1 | OK (v20.20.2) |
| #6 | qs 6.11.2 → 6.14.2 | OK (v20.20.2) |

Safe to merge. They will each need a rebase first — their checks are red because
they were opened against pre-phase-1 `main` with the Node 16 actions, not because
of anything in the bumps.

## Still open, deliberately

Both need a decision rather than an assumption:

- **Branch protection on `main`** — the plan asks for required checks before
  merge. That changes how you work on your own repo (no more direct pushes), so
  I have not enabled it.
- **Tagging `v0.1.1`** — has to happen on `main` after this merges, so it cannot
  be part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
