### PR TITLE
fix(validation): report export errors instead of crashing on them

### DIFF
--- a/validation/example_1_node.js
+++ b/validation/example_1_node.js
@@ -223,7 +223,13 @@ ee.data.authenticateViaPrivateKey(privateKey, () => {
               const fileName = vis.description + '.tif';
               downloadFile(fileName, folderName);
             } catch (error) {
-              console.error('Error in export: ' + e);  
+              // The binding is `error`; referencing `e` here threw
+              // ReferenceError from inside the handler, so the real failure was
+              // never printed and the process died on the error path instead.
+              console.error(
+                'Error in export of ' + vis.description + ': ' + error
+              );
+              process.exitCode = 1;
             }
           }
         );


### PR DESCRIPTION
The validation workflow failed on the merge of #4:

```
/app/example_1_node.js:226
              console.error('Error in export: ' + e);
                                                  ^
ReferenceError: e is not defined
```

The catch binding is `error`; the body referenced `e`. **On the error path the
handler itself threw**, so the real failure was never printed and the process died
with a `ReferenceError` that says nothing about what went wrong.

This sits on the path taken when an Earth Engine export task does not reach
`COMPLETED`. The run's log shows tasks cycling through `READY` — queued, not
finished — so the harness hit a genuine export problem and then lost the message
that would explain it.

## What changed

Fixed the reference, named the band in the message, and set a non-zero exit code
so a failed export fails the job rather than being a line in the log.

```js
} catch (error) {
  console.error('Error in export of ' + vis.description + ': ' + error);
  process.exitCode = 1;
}
```

## Why this probably matters more than it looks

It very likely explains the partial downloads seen earlier. An older validation
run compared **3 of 8 bands** — `TCWV`, `TCWVpos`, `FVC`, `TIR_BT` and
`LST_Celsius_Raw` were all reported "not found" on the JavaScript side — and still
exited 0. Same error path, same silence.

**No guess at the underlying fix.** Whether the cause is a timeout, a quota limit
or something else is not yet known; restoring the error message is what will tell
us. Fixing the symptom before seeing the error would be guessing.

## Verification

- `node --check` under `node:20`: syntax OK.
- Audited the other three `catch` blocks in the file — all reference their binding
  correctly.

Worth noting: **nothing lints this file.** `flake8` and `black` cover Python only,
so a plain undefined-variable reference sat here unnoticed. A JS linter in CI
would be a reasonable follow-up, though it is outside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)