### PR TITLE
fix(validation): retry the Drive lookup after an export completes

### DIFF
--- a/validation/example_1_node.js
+++ b/validation/example_1_node.js
@@ -64,6 +64,40 @@ const cleanupGDriveFolder = async (folderName) => {
 };
 
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Earth Engine reports a task COMPLETED as soon as its own side is done, but
+// the exported file takes a further moment to become listable in Drive. A
+// single lookup therefore misses roughly half of them: in run 30855338134 all
+// 8 tasks reached COMPLETED and 4 downloads still reported "not found".
+const FILE_LOOKUP_ATTEMPTS = 12;
+const FILE_LOOKUP_DELAY_MS = 10000;
+
+async function findFileId(driveService, fileName, folderId, folderName) {
+  for (let attempt = 1; attempt <= FILE_LOOKUP_ATTEMPTS; attempt++) {
+      const fileResults = await driveService.files.list({
+          q: `name='${fileName}' and '${folderId}' in parents and trashed=false`,
+          fields: "files(id)"
+      });
+      const files = fileResults.data.files;
+      if (files && files.length > 0) {
+          if (attempt > 1) {
+              console.log(`${fileName} appeared in Drive after ${attempt} lookups.`);
+          }
+          return files[0].id;
+      }
+      if (attempt < FILE_LOOKUP_ATTEMPTS) {
+          console.log(
+            `${fileName} not listable in ${folderName} yet ` +
+            `(lookup ${attempt}/${FILE_LOOKUP_ATTEMPTS}); retrying in ` +
+            `${FILE_LOOKUP_DELAY_MS / 1000}s`
+          );
+          await sleep(FILE_LOOKUP_DELAY_MS);
+      }
+  }
+  return null;
+}
+
 async function downloadFile(fileName, folderName) {
   const driveService = google.drive({ version: 'v3', auth: jwtClient });
   try {
@@ -75,21 +109,20 @@ async function downloadFile(fileName, folderName) {
       const folders = folderResults.data.files;
       if (!folders || folders.length === 0) {
           console.error(`Folder ${folderName} not found.`);
-          return;
+          return false;
       }
       const folderId = folders[0].id;
-      
-      const fileResults = await driveService.files.list({
-          q: `name='${fileName}' and '${folderId}' in parents`,
-          fields: "files(id)"
-      });
-      const files = fileResults.data.files;
-      if (!files || files.length === 0) {
-          console.error(`File ${fileName} not found in folder ${folderName}.`);
-          return;
+
+      const fileId = await findFileId(driveService, fileName, folderId, folderName);
+      if (!fileId) {
+          console.error(
+            `File ${fileName} not found in folder ${folderName} after ` +
+            `${FILE_LOOKUP_ATTEMPTS} lookups over ` +
+            `${(FILE_LOOKUP_ATTEMPTS * FILE_LOOKUP_DELAY_MS) / 1000}s.`
+          );
+          return false;
       }
-      const fileId = files[0].id;
-      
+
       // Step 2: Download the file
       const dest = fs.createWriteStream(path.join(downloadPath, fileName));
       const res = await driveService.files.get({
@@ -98,19 +131,22 @@ async function downloadFile(fileName, folderName) {
       }, {
           responseType: 'stream'
       });
-      
-      res.data
-          .on('end', () => {
-              console.log(`File ${fileName} downloaded successfully.`);
-          })
-          .on('error', err => {
-              console.error('Error downloading file:', err);
-              dest.close();
-          })
-          .pipe(dest);
-      
+
+      // Wait for the write stream to finish, not just the read stream to end.
+      // Returning early left the process free to exit mid-write.
+      await new Promise((resolve, reject) => {
+          dest.on('finish', resolve);
+          dest.on('error', reject);
+          res.data.on('error', reject);
+          res.data.pipe(dest);
+      });
+
+      console.log(`File ${fileName} downloaded successfully.`);
+      return true;
+
   } catch (error) {
-      console.error('Error:', error.message);
+      console.error(`Error downloading ${fileName}:`, error.message);
+      return false;
   }
 }
 
@@ -221,7 +257,13 @@ ee.data.authenticateViaPrivateKey(privateKey, () => {
               await logTaskStatusAsync(exportTask.id, vis.description);  // Log the status of this task periodically
               console.log(vis.description + ' export completed!');
               const fileName = vis.description + '.tif';
-              downloadFile(fileName, folderName);
+              // Awaited: previously this was fire-and-forget, so a failed
+              // download was a log line the job never noticed.
+              const downloaded = await downloadFile(fileName, folderName);
+              if (!downloaded) {
+                console.error('Download failed for ' + vis.description);
+                process.exitCode = 1;
+              }
             } catch (error) {
               // The binding is `error`; referencing `e` here threw
               // ReferenceError from inside the handler, so the real failure was


### PR DESCRIPTION
Root cause of the failing validation runs. **It is not an export problem, and it is not a regression in the Python port.**

## What the logs actually show

Run `30855338134` (commit `344d7e2`, the first with the repaired error handler):

```
TIR_BT status: COMPLETED          File TIR_BT.tif not found in folder node_lst_geotiffs.
TCWV status: COMPLETED            File TCWV.tif not found in folder node_lst_geotiffs.
TCWVpos status: COMPLETED         File TCWVpos.tif not found in folder node_lst_geotiffs.
Emissivity status: COMPLETED      File Emissivity.tif not found in folder node_lst_geotiffs.
FVC status: COMPLETED             File FVC.tif downloaded successfully.
LST status: COMPLETED             File LST.tif downloaded successfully.
LST_Celsius_Raw status: COMPLETED File LST_Celsius_Raw.tif downloaded successfully.
RGB status: COMPLETED             File RGB.tif downloaded successfully.
```

**All 8 exports reached `COMPLETED`.** No timeout, no quota limit — the earlier `READY` cycling was just normal polling. Four *downloads* failed.

Earth Engine reports a task `COMPLETED` as soon as its own side is done; the file takes a further moment to become listable in Drive. `downloadFile` did a single `files.list` and gave up, so about half were missed.

## The Python container proves it

Python gets 8 of 8 every time. The difference is structural, not environmental:

- **Python** runs exports *sequentially*, polling each to completion, then calls `download_files()` **once, after all of them finish**. Every file has had minutes to surface.
- **Node** downloads from inside each export's own callback, **immediately**, with one lookup.

Same Drive, same service account, same folder. Only the timing differs.

## Fixes

1. **`findFileId` retries** — 12 attempts, 10s apart, up to two minutes per file — and logs each retry, so a future stall is visible rather than inferred.
2. **`downloadFile` awaits the write stream's `finish`**, not the read stream's `end`. It was returning before bytes were flushed, leaving the process free to exit mid-write.
3. **The caller awaits `downloadFile`** and sets a non-zero exit code on failure. It was fire-and-forget, so a failed download was a log line the job never acted on.

Also adds `trashed=false` to the query — the folder is cleaned at the start of each run, and trashed files would otherwise still match.

## What this does not change

**Every band that did get compared matched exactly.**

```
Comparing FVC.tif...             Mean 0.00  Max 0.00  Min 0.00
Comparing LST.tif...             Mean 0.00  Max 0.00  Min 0.00
Comparing LST_Celsius_Raw.tif... Mean 0.00  Max 0.00  Min 0.00
Comparing RGB.tif...             Mean 0.00  Max 0.00  Min 0.00
```

The port is correct. The harness was failing to check most of it — and before phase 6's symmetric band check, it was passing while doing so.

## Verification

`node --check` under `node:20`: syntax OK. Audited all four `catch` blocks — each references its binding. Confirmed no fire-and-forget `downloadFile` calls remain.

The real test is the next validation run on `main`, which takes ~28 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)